### PR TITLE
Disable enemy flinching animation

### DIFF
--- a/autoPlay.js
+++ b/autoPlay.js
@@ -21,6 +21,13 @@ if (window.g_Minigame !== undefined) {
 	}
 }
 
+// disable enemy flinching animation when they get hit
+if (window.CEnemy !== undefined) {
+	window.CEnemy.prototype.TakeDamage = function() {};
+	window.CEnemySpawner.prototype.TakeDamage = function() {};
+	window.CEnemyBoss.prototype.TakeDamage = function() {};
+}
+
 if (thingTimer !== undefined) {
 	window.clearTimeout(thingTimer);
 }


### PR DESCRIPTION
Additional improvement on #17

Edit: the monsters (enemies, spawners and bosses) will stay in their idle position after they spawn until they die.
