### PR TITLE
Added use of Morale Booster if possible

### DIFF
--- a/autoPlay.js
+++ b/autoPlay.js
@@ -2,7 +2,7 @@
 // @name Monster Minigame Auto-script
 // @namespace https://github.com/mouseas/steamSummerMinigame
 // @description A script that runs the Steam Monster Minigame for you.
-// @version 1.2
+// @version 1.3
 // @match http://steamcommunity.com/minigame/towerattack*
 // @updateURL https://raw.githubusercontent.com/mouseas/steamSummerMinigame/master/autoPlay.js
 // @downloadURL https://raw.githubusercontent.com/mouseas/steamSummerMinigame/master/autoPlay.js

--- a/autoPlay.js
+++ b/autoPlay.js
@@ -42,6 +42,7 @@ function doTheThing() {
 	
 	useGoodLuckCharmIfRelevant();
 	useMedicsIfRelevant();
+	useMoraleBoosterIfRelevant();
 	useClusterBombIfRelevant();
 	useNapalmIfRelevant();
 	
@@ -263,6 +264,34 @@ function useNapalmIfRelevant() {
 		//Burn them all if spawner and 2+ other monsters
 		if (enemySpawnerExists && enemyCount >= 3) {
 			triggerAbility(12);
+		}
+	}
+}
+
+function useMoraleBoosterIfRelevant() {
+	// Check if Morale Booster is purchased
+	if(hasPurchasedAbility(5)) {
+		if (isAbilityCoolingDown(5)) {
+			return;
+		}
+		
+		//Check lane has monsters so the hype isn't wasted
+		var currentLane = g_Minigame.CurrentScene().m_nExpectedLane;
+		var enemyCount = 0;
+		var enemySpawnerExists = false;
+		//Count each slot in lane
+		for (var i = 0; i < 4; i++) {
+			var enemy = g_Minigame.CurrentScene().GetEnemy(currentLane, i);
+			if (enemy) {
+				enemyCount++;
+				if (enemy.m_data.type == 0) { 
+					enemySpawnerExists = true;
+				}
+			}
+		}
+		//Hype everybody up!
+		if (enemySpawnerExists && enemyCount >= 3) {
+			triggerAbility(5);
 		}
 	}
 }


### PR DESCRIPTION
Just another addition of an ability we can use. I put the method call before Cluster Bomb and Napalm because Morale Booster's tool tip does not specify that it only applies to clicks. I doubt it will actually buff Cluster Bomb and Napalm, but better safe than sorry.
