### PR TITLE
Golden Rain Auto Clicker Toggle

### DIFF
--- a/main.user.js
+++ b/main.user.js
@@ -26,7 +26,7 @@
 ///////////////////////////////////////////////////////////
 
 var isAlreadyRunning = false;
-var autoClickGoldRain = true;
+var autoClickGoldRain = false;
 
 var clickRate = 10; // change to number of desired clicks per second
 var timer = 0;
@@ -88,6 +88,9 @@ function firstRun() {
 		CEnemySpawner.prototype.TakeDamage = function() {};
 		CEnemyBoss.prototype.TakeDamage = function() {};
 	}
+
+	// add some extra buttons
+	jQuery(".toggle_music_btn").after("<span onclick=\"toggleGoldenRainAutoClick()\" class=\"toggle_music_btn\" id=\"GRACSpan\">Golden Rain Clicker<br/><span id=\"GRACStaus\">Currently Off</span></span>");
 }
 
 function doTheThing() {
@@ -582,10 +585,13 @@ function clickTheThing() {
 	// There's a reddit thread about why and we might as well be safe
 	g_msTickRate = 1100;
 
-	g_Minigame.m_CurrentScene.DoClick(
+	// Check if we should still click...we might get turned off/on
+	// during a Golden Rain
+	if (autoClickGoldRain) {
+		g_Minigame.m_CurrentScene.DoClick(
 		{
 			data: {
-				getLocalPosition: function() {
+				getLocalPosition: function () {
 					var enemy = g_Minigame.m_CurrentScene.GetEnemy(
 						g_Minigame.m_CurrentScene.m_rgPlayerData.current_lane,
 						g_Minigame.m_CurrentScene.m_rgPlayerData.target);
@@ -598,7 +604,8 @@ function clickTheThing() {
 				}
 			}
 		}
-	);
+		);
+	}
 	timer = timer - 1;
 }
 
@@ -635,3 +642,16 @@ var thingTimer = window.setInterval(function(){
 		thingTimer = window.setInterval(doTheThing, 1000);
 	}
 }, 1000);
+
+// Toggles the Golden Rain Auto Clicker On and Off
+// Also updates the button on the UI
+function toggleGoldenRainAutoClick() {
+	var status = "Off";
+	autoClickGoldRain = !autoClickGoldRain;
+
+	if (autoClickGoldRain) {
+		status = "On";
+	}
+
+	jQuery("#GRACStaus").text("Currently " + status);
+}


### PR DESCRIPTION
First pass at adding a button to toggle auto-clicking on and off; I won't have much time to look at this further during the week, so I'm throwing this out there in case it is a useful starting point.

The button is added next to the SFX and Music toggles, which will turn
on/off the Golden Rain auto-clicking - the button styling isn't all that great, with the text slightly overflowing the bounds (also, it looks like the SFX/Music buttons!), but is at least functional.

In this change I've turned **off** the auto-clicking by default, since it seems to me that the aim of this script is generally not to auto-click. Now a single click using the in-game interface will get it back. But I'd understand if this change is frowned upon.

In my own testing I found the button to work, including mid auto-click, but I won't claim my testing to be extensive.
