### PR TITLE
Reduce weighting towards click upgrades

### DIFF
--- a/main.user.js
+++ b/main.user.js
@@ -346,7 +346,7 @@ function goToLaneWithBestTarget() {
 
 function purchaseUpgrades() {
 	var oddsOfElement = 1 - (0.75*0.75*0.75); //This values elemental too much because best element lanes are not focused(0.578)
-	var avgClicksPerSecond = 3;	//Set this yourself to serve your needs
+	var avgClicksPerSecond = 1;	//Set this yourself to serve your needs
 	
 	var upgrades = g_Minigame.CurrentScene().m_rgTuningData.upgrades.slice(0);
 	var playerUpgrades = g_Minigame.CurrentScene().m_rgPlayerUpgrades;


### PR DESCRIPTION
With a higher CPS setting, the upgrade purchasing is biased towards click upgrades over idle upgrades.
With clicks only being automatically performed during boss battles every ten levels, `1` is probably a more reasonable default.

(I use a smaller fraction myself, since I tend to go idle frequently)
