### PR TITLE
Use treasure on bosses when triggering metal detector

### DIFF
--- a/main.user.js
+++ b/main.user.js
@@ -123,7 +123,7 @@ function doTheThing() {
 		useNapalmIfRelevant();
 		useTacticalNukeIfRelevant();
 		useCrippleSpawnerIfRelevant();
-		useMetalDetectorIfRelevant();
+		useMetalDetectorAndTreasureIfRelevant();
 		useGoldRainIfRelevant();
 		attemptRespawn();
 
@@ -628,20 +628,21 @@ function useTacticalNukeIfRelevant() {
 	}
 }
 
-function useMetalDetectorIfRelevant() {
-	if (hasPurchasedAbility(ABILITIES.METAL_DETECTOR)) {
-		if (isAbilityCoolingDown(ABILITIES.METAL_DETECTOR)) {
-			return;
-		}
+function useMetalDetectorAndTreasureIfRelevant() {
 
-		var enemy = g_Minigame.m_CurrentScene.GetEnemy(g_Minigame.m_CurrentScene.m_rgPlayerData.current_lane, g_Minigame.m_CurrentScene.m_rgPlayerData.target);
+	var enemy = g_Minigame.m_CurrentScene.GetEnemy(g_Minigame.m_CurrentScene.m_rgPlayerData.current_lane, g_Minigame.m_CurrentScene.m_rgPlayerData.target);
 
-		if (enemy && enemy.m_data.type == ENEMY_TYPE.BOSS) {
-			var enemyBossHealthPercent = enemy.m_flDisplayedHP / enemy.m_data.max_hp;
+	if (enemy && enemy.m_data.type == ENEMY_TYPE.BOSS) {
+		var enemyBossHealthPercent = enemy.m_flDisplayedHP / enemy.m_data.max_hp;
 
-			if (enemyBossHealthPercent < 0.3 ) {
+		if (enemyBossHealthPercent < 0.3) {
+			if (hasPurchasedAbility(ABILITIES.METAL_DETECTOR) && !isAbilityCoolingDown(ABILITIES.METAL_DETECTOR)) {
 				console.log('Metal detector is purchased and cooled down, Triggering it on boss');
 				triggerAbility(ABILITIES.METAL_DETECTOR);
+			}
+			if (numItem(ITEMS.TREASURE) && !isAbilityCoolingDown(ITEMS.TREASURE)) {
+				console.log('Treasure! is purchased and cooled down, Triggering it on boss');
+				triggerItem(ITEMS.TREASURE);
 			}
 		}
 	}


### PR DESCRIPTION
If the boss is below 30% health, attempt to trigger Treasure in addition to Metal Detector.

Since treasure has a short cooldown (5s), it may trigger it multiple times on the same boss.

I also attempted to estimate the time till the boss will be defeated, to do a better triggering condition for bosses that may take longer than the 20 second effect time, but just calculating `health / dps` was usually not very correct.
