### PR TITLE
Reduce chance of using cripple spawner

### DIFF
--- a/main.user.js
+++ b/main.user.js
@@ -670,7 +670,7 @@ function useCrippleSpawnerIfRelevant() {
 		}
 
 		// If there is a spawner and it's health is above 95%, cripple it!
-		if (enemySpawnerExists && enemySpawnerHealthPercent > 0.95) {
+		if (enemySpawnerExists && enemySpawnerHealthPercent > 0.95 && Math.random() < 1/50) {
 			console.log("Cripple Spawner available, and needed. Cripple 'em.");
 			triggerItem(ITEMS.CRIPPLE_SPAWNER);
 		}


### PR DESCRIPTION
I've seen many times when several players use Cripple Spawner at once, which wastes its use; It's probably most likely to happen right after loot is dropped. The probability can be discussed, but I think it's valuable to limit the chance of using Cripple Spawner so that it's spread out among more levels & lanes.
